### PR TITLE
Wrap typeof(object)

### DIFF
--- a/WPF/UpdateControls.XAML/Wrapper/ClassProperty.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ClassProperty.cs
@@ -28,7 +28,6 @@ namespace UpdateControls.XAML.Wrapper
     {
         private static readonly Type[] Primitives = new Type[]
         {
-			typeof(object),
             typeof(string),
             typeof(Uri),
             typeof(Cursor)


### PR DESCRIPTION
Wrap typeof(object) in order to allow view models to return other view models of unknown type. This is actually quite common scenario in GUI where single window area can serve many different purposes.

Perhaps this could be decided dynamically in the future. It's much better to look at the actual type of returned object rather than relying on property definition. For now, I have just removed the restriction on typeof(object).
