### PR TITLE
Tolerate null collections

### DIFF
--- a/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyCollection.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyCollection.cs
@@ -41,6 +41,12 @@ namespace UpdateControls.XAML.Wrapper
         {
             // Get the source collection from the wrapped object.
             IEnumerable source = ClassProperty.GetObjectValue(ObjectInstance.WrappedObject) as IEnumerable;
+            if (source == null)
+            {
+                _collection = null;
+                return;
+            }
+
             List<object> sourceCollection = source.OfType<object>().ToList();
 
             // Delay the update to the observable collection so that we don't record dependencies on


### PR DESCRIPTION
UpdateControls throws exceptions when some view model happens to return null collection. This patch fixes the problem by forwarding the null value down to the XAML code, which seems to be the logical thing to do.
