### PR TITLE
DependentJob as a simpler replacement for raw Dependent

### DIFF
--- a/Portable/UpdateControls/DependentJob.cs
+++ b/Portable/UpdateControls/DependentJob.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace UpdateControls
+{
+    public class DependentJob : IUpdatable, IDisposable
+    {
+        Dependent _dependent;
+        bool _running;
+
+        public DependentJob(Action action)
+        {
+            _dependent = new Dependent(action);
+            _dependent.Invalidated += () => UpdateScheduler.ScheduleUpdate(this);
+        }
+
+        public void Start()
+        {
+            if (_dependent == null)
+                throw new InvalidOperationException("Cannot restart DependentJob");
+            _running = true;
+            UpdateScheduler.ScheduleUpdate(this);
+        }
+
+        public void Stop()
+        {
+            _running = false;
+            _dependent.Dispose();
+            _dependent = null;
+        }
+
+        public void Dispose() { Stop(); }
+
+        void IUpdatable.UpdateNow()
+        {
+            if (_running)
+                _dependent.OnGet();
+        }
+    }
+}

--- a/Portable/UpdateControls/UpdateControls.csproj
+++ b/Portable/UpdateControls/UpdateControls.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Collections\IndependentDictionary.cs" />
     <Compile Include="Collections\IndependentList.cs" />
     <Compile Include="Dependent.cs" />
+    <Compile Include="DependentJob.cs" />
     <Compile Include="Fields\Dependent.cs" />
     <Compile Include="Fields\Independent.cs" />
     <Compile Include="Independent.cs" />


### PR DESCRIPTION
DependentJob ensures that the specified task executes whenever anything used during the task changes. This is useful for implementing pumps that forward changes from UpdateControls to external system not managed by UpdateControls. It is also useful to implement data triggers with non-GUI side effects.

Similar functionality can be obtained with plain Dependent. I find DependentJob much more intuitive with its Start/Stop methods than Dependent's OnGet/Invalidated/ScheduleUpdate.
