### PR TITLE
Binding interceptor

### DIFF
--- a/WPF/UpdateControls.XAML/BindingInterceptor.cs
+++ b/WPF/UpdateControls.XAML/BindingInterceptor.cs
@@ -15,7 +15,6 @@ namespace UpdateControls.XAML
         public virtual object GetValue(ObjectProperty property) { return property.ContinueGetValue(); }
         public virtual void SetValue(ObjectProperty property, object value) { property.ContinueSetValue(value); }
         public virtual void UpdateValue(ObjectProperty property) { property.ContinueUpdateValue(); }
-        public virtual bool CanExecute(object wrappedObject, ClassMemberCommand command) { return command.ContinueCanExecute(wrappedObject); }
-        public virtual void Execute(object wrappedObject, ClassMemberCommand command) { command.ContinueExecute(wrappedObject); }
+        public virtual void Execute(ObjectPropertyCommand command) { command.ContinueExecute(); }
     }
 }

--- a/WPF/UpdateControls.XAML/UpdateControls.XAML.csproj
+++ b/WPF/UpdateControls.XAML/UpdateControls.XAML.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Wrapper\ClassMemberProperty.cs" />
     <Compile Include="Wrapper\CollectionItem.cs" />
     <Compile Include="Wrapper\IObjectInstance.cs" />
+    <Compile Include="Wrapper\ObjectPropertyCommand.cs" />
     <Compile Include="Wrapper\ObjectInstance.cs" />
     <Compile Include="Wrapper\ObjectProperty.cs" />
     <Compile Include="Wrapper\ObjectPropertyAtom.cs" />

--- a/WPF/UpdateControls.XAML/Wrapper/ClassMember.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ClassMember.cs
@@ -70,7 +70,13 @@ namespace UpdateControls.XAML.Wrapper
 
             // Determine which type of object property to create.
             Type valueType;
-            if (IsPrimitive(propertyType))
+            if (propertyType == typeof(ObjectPropertyCommand))
+            {
+                _makeObjectProperty = objectInstance =>
+                    new ObjectPropertyCommand(objectInstance, (ClassMemberCommand)this);
+                valueType = propertyType;
+            }
+            else if (IsPrimitive(propertyType))
             {
                 _makeObjectProperty = objectInstance =>
                     new ObjectPropertyAtomNative(objectInstance, this);

--- a/WPF/UpdateControls.XAML/Wrapper/ClassMemberCommand.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ClassMemberCommand.cs
@@ -10,38 +10,18 @@ namespace UpdateControls.XAML.Wrapper
 {
     public class ClassMemberCommand : ClassMember
     {
-        MethodInfo _method;
-        ClassMember _condition;
+        public MethodInfo ExecuteMethod { get; private set; }
+        public ClassMember CanExecuteProperty { get; private set; }
 
         public ClassMemberCommand(MethodInfo method, ClassMember condition, Type objectInstanceType)
-            : base(method.Name, typeof(ICommand), objectInstanceType)
+            : base(method.Name, typeof(ObjectPropertyCommand), objectInstanceType)
         {
-            _method = method;
-            _condition = condition;
+            ExecuteMethod = method;
+            CanExecuteProperty = condition;
         }
 
-        public override object GetObjectValue(object wrappedObject)
-        {
-            Action execute = () => BindingInterceptor.Current.Execute(wrappedObject, this);
-            if (_condition != null)
-                return MakeCommand.When(() => BindingInterceptor.Current.CanExecute(wrappedObject, this)).Do(execute);
-            else
-                return MakeCommand.Do(execute);
-        }
-
-        public override void SetObjectValue(object wrappedObject, object value)
-        {
-        }
-
-        internal bool ContinueCanExecute(object wrappedObject)
-        {
-            return (bool)_condition.GetObjectValue(wrappedObject);
-        }
-
-        internal void ContinueExecute(object wrappedObject)
-        {
-            _method.Invoke(wrappedObject, new object[0]);
-        }
+        public override object GetObjectValue(object wrappedObject) { return null; }
+        public override void SetObjectValue(object wrappedObject, object value) { }
 
         public override bool CanRead
         {
@@ -50,7 +30,7 @@ namespace UpdateControls.XAML.Wrapper
 
         public override Type UnderlyingType
         {
-            get { return typeof(ICommand); }
+            get { return typeof(ObjectPropertyCommand); }
         }
 
         public override bool IsReadOnly

--- a/WPF/UpdateControls.XAML/Wrapper/ObjectProperty.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ObjectProperty.cs
@@ -10,6 +10,7 @@
  **********************************************************************/
 
 using System;
+using System.ComponentModel;
 using System.Windows.Threading;
 
 namespace UpdateControls.XAML.Wrapper
@@ -18,6 +19,8 @@ namespace UpdateControls.XAML.Wrapper
 	{
 		public IObjectInstance ObjectInstance { get; private set; }
 		public ClassMember ClassProperty { get; private set; }
+
+        public event EventHandler PropertyChanged;
 
         public ObjectProperty(IObjectInstance objectInstance, ClassMember classProperty)
 		{
@@ -53,5 +56,12 @@ namespace UpdateControls.XAML.Wrapper
 				.GetConstructor(new Type[] { typeof(object), typeof(Dispatcher) })
 				.Invoke(new object[] { value, ObjectInstance.Dispatcher });
 		}
+
+        protected void FirePropertyChanged()
+        {
+            ObjectInstance.FirePropertyChanged(ClassProperty.Name);
+            if (PropertyChanged != null)
+                PropertyChanged(this, EventArgs.Empty);
+        }
 	}
 }

--- a/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyAtom.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyAtom.cs
@@ -68,7 +68,7 @@ namespace UpdateControls.XAML.Wrapper
             if (!Object.Equals(_value, value))
                 _value = value;
             if (_firePropertyChanged)
-                ObjectInstance.FirePropertyChanged(ClassProperty.Name);
+                FirePropertyChanged();
             _firePropertyChanged = true;
         }
 

--- a/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyCollection.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyCollection.cs
@@ -58,7 +58,7 @@ namespace UpdateControls.XAML.Wrapper
 				if (_collection == null)
 				{
 					_collection = new ObservableCollection<object>();
-					ObjectInstance.FirePropertyChanged(ClassProperty.Name);
+                    FirePropertyChanged();
 				}
 
                 // Create a list of new items.

--- a/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyCommand.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyCommand.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace UpdateControls.XAML.Wrapper
+{
+    public class ObjectPropertyCommand : ObjectProperty, ICommand
+    {
+        ObjectProperty _canProperty;
+
+        public ClassMemberCommand ClassCommand { get; private set; }
+
+        public ObjectProperty CanExecuteProperty
+        {
+            get
+            {
+                if (_canProperty == null && ClassCommand.CanExecuteProperty != null)
+                {
+                    _canProperty = ObjectInstance.LookupProperty(ClassCommand.CanExecuteProperty);
+                    _canProperty.PropertyChanged += (sender, args) =>
+                    {
+                        if (CanExecuteChanged != null)
+                            CanExecuteChanged(this, EventArgs.Empty);
+                    };
+                }
+                return _canProperty;
+            }
+        }
+
+        public event EventHandler CanExecuteChanged;
+
+        public ObjectPropertyCommand(IObjectInstance objectInstance, ClassMemberCommand classCommand)
+            : base(objectInstance, classCommand)
+        {
+            ClassCommand = classCommand;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            if (CanExecuteProperty != null)
+                return (bool)CanExecuteProperty.Value;
+            else
+                return true;
+        }
+
+        public void Execute(object parameter)
+        {
+            BindingInterceptor.Current.Execute(this);
+        }
+
+        internal void ContinueExecute()
+        {
+            ClassCommand.ExecuteMethod.Invoke(ObjectInstance.WrappedObject, new object[0]);
+        }
+
+        protected override object GetValue() { return this; }
+        protected override void SetValue(object value) { }
+        protected override void UpdateValue() { }
+    }
+}


### PR DESCRIPTION
Implemented BindingInterceptor that enables app developers to intercept property access, dependent refresh, and command execution. It's mostly useful for logging and custom exception handling.

This is my last patch. I will likely get back to UpdateControls a bit later this year, perhaps as soon as a few weeks later. Please do whatever cleanup you had in mind.

While patching UpdateControls, I ran into three main issues with project structure.
1. Platform projects should share source code, because they are nearly identical. Platform-specific parts should be controlled through #if ... #endif. That would allow me to contribute to all platform projects at the same time.
2. Projects for platform unit test should be created. Again, they should share code with occasional #if ... #endif. That would make it easier to drop in some unit tests while making changes.
3. Some general mechanism is needed that would allow portable code to call platform code. Actually the only time I needed this was for timers, which have their own custom solution via SynchronizationContext. So this last point might turn out to be unnecessary at the moment.

These structural changes would make it easier to contribute to UpdateControls.
