### PR TITLE
Do not wrap primitive types from typeof(object) properties

### DIFF
--- a/WPF/UpdateControls.XAML/Wrapper/ClassMember.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ClassMember.cs
@@ -152,7 +152,7 @@ namespace UpdateControls.XAML.Wrapper
             return objectProperty;
         }
 
-        private static bool IsPrimitive(Type type)
+        internal static bool IsPrimitive(Type type)
         {
             return
                 type.IsValueType ||

--- a/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyAtomObject.cs
+++ b/WPF/UpdateControls.XAML/Wrapper/ObjectPropertyAtomObject.cs
@@ -10,6 +10,7 @@
  **********************************************************************/
 
 using System;
+using System.Collections;
 
 namespace UpdateControls.XAML.Wrapper
 {
@@ -22,12 +23,17 @@ namespace UpdateControls.XAML.Wrapper
 
         public override object TranslateIncommingValue(object value)
         {
-            return value == null ? null : ((IObjectInstance)value).WrappedObject;
+            var instance = value as IObjectInstance;
+            return instance != null ? instance.WrappedObject : value;
         }
 
         public override object TranslateOutgoingValue(object value)
         {
-            return value == null ? null : WrapObject(value);
+            if (value == null)
+                return null;
+            if (ClassProperty.UnderlyingType == typeof(object) && (ClassMember.IsPrimitive(value.GetType()) || typeof(IEnumerable).IsAssignableFrom(value.GetType())))
+                return value;
+            return WrapObject(value);
         }
     }
 }


### PR DESCRIPTION
This is a small fix. When #9 introduced wrapping for `object` properties, UpdateControls started wrapping primitive values if they happened to be stored in such property. This fix checks actual type of the value stored in `object` property and wraps it only if it is not primitive type.

This adds to my argument that wrapping decisions must be done at runtime. In WPF, there are bound to be many such untyped `object` properties that can carry primitive values and complex models with equal probability. The logic in ClassMember is fatally flawed since it relies on incomplete compile-time type information.

IMO, checking compile-time type of the property is merely an optimization. It is useful to avoid having to do runtime checks in the usual case of strongly typed property, but it shouldn't replace the runtime mechanism entirely as it is unable to handle weakly typed properties.
