### PR TITLE
Error when trying to use UpdateControls on Release Mode.

### DIFF
--- a/WPF/UpdateControls.XAML/ViewModelLocatorBase.cs
+++ b/WPF/UpdateControls.XAML/ViewModelLocatorBase.cs
@@ -50,15 +50,12 @@ namespace UpdateControls.XAML
             get { return _designMode; }
         }
 
-        public object ViewModel(Func<object> constructor)
+        public object ViewModel(Func<object> constructor, [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
         {
             if (DesignMode)
                 return constructor();
 
-            string caller = new StackFrame(1).GetMethod().Name;
-            if (!caller.StartsWith("get_"))
-                throw new ArgumentException("Only call ViewModel from a property getter.");
-            string propertyName = caller.Substring(4);
+            string propertyName = memberName;
 
             ForView.Initialize();
             ViewModelContainer container;


### PR DESCRIPTION
changing StackFrame(1).GetMethod() from System.Diagnostics for CompilerServices.CallerMemberName to be able to obtain the method name even on release mode.

After trying to compile and run the application on release mode using UpdateControls, seems that using System.Diagnostics is not allowing to obtain the method call name. 
Instead using  CompilerServices.CallerMemberName seems to fix the problem.

Waiting for your comments.

Thank you.
